### PR TITLE
Re-add random `sleep` during loot collection

### DIFF
--- a/ClAsHbOt Script/CollectLoot.au3
+++ b/ClAsHbOt Script/CollectLoot.au3
@@ -27,7 +27,7 @@ Func CollectLoot()
 		 RandomWeightedClick($button)
 
 		 ;DebugWrite("Loot: " & $sortedX[$i] & "," & $sortedY[$i])
-		 ;Sleep(Random(100, 500, 1))
+		 Sleep(Random(100, 500, 1))
 	  Next
 
 	  Sleep(1000)


### PR DESCRIPTION
Noticed that the `sleep` was commented out, which causes all loot to be collected instantly. Un-commenting it for more human-esque loot collection.
